### PR TITLE
turn on optimization, integrate error reports with native code cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ If you apply the diff (i.e. update and save the demo.jl), TP will automatically 
 > git apply fix-demo.jl.diff
 
 ```julia
-profiling from demo.jl ... (finished in 5.146 sec)
+profiling from demo.jl ... (finished in 4.09 sec)
 No errors !
 ```
 

--- a/src/TypeProfiler.jl
+++ b/src/TypeProfiler.jl
@@ -12,17 +12,20 @@ import Core.Compiler:
     # abstractinterpretation.jl
     abstract_call_gf_by_type, abstract_call_known, abstract_call,
     abstract_eval_special_value, abstract_eval_value_expr, abstract_eval_value,
-    abstract_eval_statement, builtin_tfunction, typeinf_local
+    abstract_eval_statement, builtin_tfunction, typeinf_local, typeinf_edge,
+    # tpcache.jl
+    WorldView
 
 # usings
 # ------
 
 # TODO: really use `using` instead
 import Core:
-    TypeofBottom
+    TypeofBottom, SimpleVector
 
 import Core.Compiler:
     AbstractInterpreter, NativeInterpreter, InferenceState, InferenceResult, CodeInfo,
+    InternalCodeCache, CodeInstance, WorldRange,
     MethodInstance, Bottom, NOT_FOUND, MethodMatchInfo, UnionSplitInfo, MethodLookupResult,
     Const, VarTable, SSAValue, SlotNumber, Slot, slot_id, GlobalRef, GotoIfNot, ReturnNode,
     widenconst, isconstType, typeintersect, ⊑, Builtin, CallMeta,
@@ -39,6 +42,8 @@ import Base.Iterators:
 
 using FileWatching, Requires
 
+const CC = Core.Compiler
+
 # includes
 # --------
 
@@ -51,6 +56,7 @@ include("virtualprocess.jl")
 include("abstractinterpreterinterface.jl")
 include("abstractinterpretation.jl")
 include("tfuncs.jl")
+include("tpcache.jl")
 include("print.jl")
 include("profile.jl")
 include("watch.jl")

--- a/src/abstractinterpreterinterface.jl
+++ b/src/abstractinterpreterinterface.jl
@@ -9,29 +9,38 @@ struct TPInterpreter <: AbstractInterpreter
     discard_trees::Bool
 
     # TypeProfiler.jl specific
+    id::Symbol                 # for escaping reporting duplicated cached reports
+    frame::Ref{InferenceState} # for constructing virtual stack frame from cached reports
     istoplevel::Bool
     virtualglobalvartable::Dict{Module,Dict{Symbol,Any}} # maybe we don't need this nested dicts
     filter_native_remarks::Bool
 
     function TPInterpreter(world::UInt = get_world_counter();
                            inf_params::InferenceParams = InferenceParams(),
-                           opt_params::OptimizationParams = OptimizationParams(),
-                           optimize::Bool = false,
+                           opt_params::OptimizationParams = OptimizationParams(;
+                               inlining = false,
+                           ),
+                           optimize::Bool = true,
                            compress::Bool = false,
                            discard_trees::Bool = false,
                            istoplevel::Bool = false,
                            virtualglobalvartable::AbstractDict = Dict(),
                            filter_native_remarks::Bool = true,
                            )
+        @assert !opt_params.inlining "inlining should be disabled"
+
         native = NativeInterpreter(world; inf_params, opt_params)
+        id     = gensym(:TPInterpreterID)
         return new(native,
                    [],
                    optimize,
                    compress,
                    discard_trees,
+                   id,
+                   Ref{InferenceState}(),
                    istoplevel,
                    virtualglobalvartable,
-                   filter_native_remarks
+                   filter_native_remarks,
                    )
     end
 end
@@ -40,7 +49,6 @@ InferenceParams(interp::TPInterpreter) = InferenceParams(interp.native)
 OptimizationParams(interp::TPInterpreter) = OptimizationParams(interp.native)
 get_world_counter(interp::TPInterpreter) = get_world_counter(interp.native)
 get_inference_cache(interp::TPInterpreter) = get_inference_cache(interp.native)
-code_cache(interp::TPInterpreter) = code_cache(interp.native)
 
 # TP only works for runtime inference
 lock_mi_inference(::TPInterpreter, ::MethodInstance) = nothing
@@ -52,7 +60,7 @@ function add_remark!(interp::TPInterpreter, ::InferenceState, report::InferenceE
 end
 function add_remark!(interp::TPInterpreter, sv::InferenceState, s::String)
     interp.filter_native_remarks && return
-    add_remark!(interp, sv, NativeRemark(sv, s))
+    add_remark!(interp, sv, NativeRemark(interp, sv, s))
     return
 end
 

--- a/src/tfuncs.jl
+++ b/src/tfuncs.jl
@@ -6,7 +6,7 @@ function builtin_tfunction(interp::TPInterpreter, @nospecialize(f), argtypes::Ar
     if f === throw
         # TODO: needs a special case here
     elseif ret === Bottom
-        add_remark!(interp, sv, InvalidBuiltinCallErrorReport(sv))
+        add_remark!(interp, sv, InvalidBuiltinCallErrorReport(interp, sv))
     end
 
     return ret

--- a/src/tpcache.jl
+++ b/src/tpcache.jl
@@ -1,0 +1,60 @@
+# global cache
+# ------------
+
+struct InferenceReportCache{T<:InferenceErrorReport}
+    st::ViewedVirtualStackTrace
+    msg::String
+    sig::String
+end
+const TPCACHE = Dict{MethodInstance,Pair{Symbol,Vector{InferenceReportCache}}}()
+
+get_id(interp::TPInterpreter) = interp.id
+
+function get_report_cache(sv, cache::InferenceReportCache{T}) where {T<:InferenceErrorReport}
+    cur_st = track_abstract_call_stack!((args...)->nothing, sv)
+    st = vcat(cache.st, cur_st)
+    return T(st, cache.msg, cache.sig)
+end
+
+# code cache interface
+# --------------------
+
+code_cache(interp::TPInterpreter) = TPCache(interp, code_cache(interp.native))
+
+struct TPCache{NativeCache}
+    interp::TPInterpreter
+    native::NativeCache
+    TPCache(interp::TPInterpreter, native::NativeCache) where {NativeCache} =
+        new{NativeCache}(interp, native)
+end
+WorldView(tpc::TPCache, wr::WorldRange) = TPCache(tpc.interp, WorldView(tpc.native, wr))
+WorldView(tpc::TPCache, args...) = WorldView(tpc, WorldRange(args...))
+
+CC.haskey(tpc::TPCache, mi::MethodInstance) = CC.haskey(tpc.native, mi)
+
+function CC.get(tpc::TPCache, mi::MethodInstance, default)
+    ret = CC.get(tpc.native, mi, default)
+
+    # cache hit, we need to append already-profiled error reports if exist
+    if ret !== default
+        # key = hash(mi)
+        if haskey(TPCACHE, mi)
+            id, cached_reports = TPCACHE[mi]
+
+            # don't append duplicated reports from the same inference process
+            if id !== get_id(tpc.interp)
+                frame = get_current_frame(tpc.interp)
+                for cache in cached_reports
+                    report = get_report_cache(frame, cache)
+                    push!(tpc.interp.reports, report)
+                end
+            end
+        end
+    end
+
+    return ret
+end
+
+CC.getindex(tpc::TPCache, mi::MethodInstance) = CC.getindex(tpc.native, mi)
+
+CC.setindex!(tpc::TPCache, ci::CodeInstance, mi::MethodInstance) = CC.setindex!(tpc.native, ci, mi)


### PR DESCRIPTION
turn on optimization, integrate error reports with native code cache

- enabling optimization will make profiling more accurate and 
performative
- we also want to reuse internal code cache logic for performance 
reasons, but we need to integrate it with our error reports (otherwise 
it will hide them, just because they don't profile code again)
- ... and for now inlining is disabled, since it will confuse the 
virtual stack frame traversal