### PR TITLE
"fix" the logic to call down into `NativeInterpreter`'s abstract interpretation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ If you apply the diff (i.e. update and save the demo.jl), TP will automatically 
 > git apply fix-demo.jl.diff
 
 ```julia
-profiling from demo.jl (finished in 3.521 sec)
+profiling from demo.jl (finished in 0.317 sec)
 No errors !
 ```
 

--- a/src/abstractinterpretation.jl
+++ b/src/abstractinterpretation.jl
@@ -4,12 +4,11 @@
 HACK: calls down to `NativeInterpreter`'s abstract interpretation method while passing
   `TPInterpreter` so that subsequent methods that are oveloaded against `TPInterpreter` can
   be called from the native method.
-`ex` is supposed to be the function definition signature of the target native method, which
 
+`ex` is supposed to be the function definition signature of the target native method, which
   can be copy-and-pasted from the native compiler code.
 
-> example: calls down to `NativeInterpreter`'s `abstract_call_gf_by_type` method.
-
+e.g. calls down to `NativeInterpreter`'s `abstract_call_gf_by_type` method:
 ```julia
 ret = @invoke_native abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f), argtypes::Vector{Any}, @nospecialize(atype), sv::InferenceState,
                                               max_methods::Int = InferenceParams(interp).MAX_METHODS)

--- a/src/tfuncs.jl
+++ b/src/tfuncs.jl
@@ -1,7 +1,8 @@
 # just relies on the native tfuncs, maybe there're lots of edge cases
 function builtin_tfunction(interp::TPInterpreter, @nospecialize(f), argtypes::Array{Any,1},
                            sv::Union{InferenceState,Nothing})
-    ret = invoke_native(builtin_tfunction, interp, f, argtypes, sv)
+    ret = @invoke_native builtin_tfunction(interp::AbstractInterpreter, @nospecialize(f), argtypes::Array{Any,1},
+                                           sv::Union{InferenceState,Nothing})
 
     # propagate virtual global variable
     if f === getfield && ret == Any && length(argtypes) == 2 && all(a->isa(a, Const), argtypes)
@@ -33,7 +34,7 @@ function return_type_tfunc(interp::TPInterpreter, argtypes::Vector{Any}, sv::Inf
         add_remark!(interp, sv, NoMethodErrorReport(interp, sv, false, argtypes_to_type(argtypes) #= this is not necessary to be computed correctly, though =#))
         return Bottom
     else
-        # don't recursively pass on `TPInterpreter` via `invoke_native`
+        # don't recursively pass on `TPInterpreter` via `@invoke_native`
         return return_type_tfunc(interp.native, argtypes, sv)
     end
 end


### PR DESCRIPTION
- previous `invoke_native` turns out to be really slow, e.g. we need to 
wait ~120 sec to `using StatsPlots; @profile_call density(rand(1000))`, 
while native JIT compilation only takes around ~7 sec for that
- the new `@invoke_native` avoids runtime type constructions and maybe 
excessive code generation, and now we can finish `@profile_call density(rand(1000))` 
within 15 sec (note that this time includes IO overheads),
which is vastly faster than the previous implementation