### PR TITLE
wip: profile on toplevel method instance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,11 @@ version = "0.0.0"
 
 [deps]
 FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+JuliaInterpreter = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+
+[compat]
+JuliaInterpreter = "0.8"
 
 [extras]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/reports.jl
+++ b/src/reports.jl
@@ -312,6 +312,11 @@ function _get_sig_type(sv::InferenceState, slot::SlotNumber)
     return Any[sig, typ], typ
 end
 _get_sig_type(::InferenceState, gr::GlobalRef) = Any[string(gr.mod, '.', gr.name)], nothing
+function _get_sig_type(sv::InferenceState, s::Symbol)
+    # for toplevel frame, we need to resolve symbols to global references by ourselves
+    istoplevel(sv) && return _get_sig_type(sv, GlobalRef(sv.mod, s))
+    return Any[repr(s; context = :compact => true)], nothing
+end
 function _get_sig_type(sv::InferenceState, gotoifnot::GotoIfNot)
     sig  = Any[string("goto %", gotoifnot.dest, " if not "), _get_sig(sv, gotoifnot.cond)...]
     return sig, nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,10 +68,15 @@ profile_file′(filename, args...; kwargs...) =
 function profile_toplevel(s,
                            virtualmod = gen_virtualmod();
                            filename = "top-level",
-                           actualmodsym = :Main,
+                           # actualmodsym = :Main,
                            interp = TPInterpreter(),
                            )
-    return virtual_process!(s, filename, actualmodsym, virtualmod, interp)
+    return virtual_process!(s,
+                            filename,
+                            # actualmodsym,
+                            virtualmod,
+                            interp
+                            )
 end
 
 # profile from expression
@@ -90,7 +95,7 @@ function _profile_toplevel(virtualmod, ex, filename)
     return quote let
         interp = $(TPInterpreter)()
         ret = $(TypeProfiler.gen_virtual_process_result)()
-        $(virtual_process!)($(toplevelex), $(filename), :Main, $(esc(virtualmod)), interp, ret)
+        $(virtual_process!)($(toplevelex), $(filename), $(esc(virtualmod)), interp, ret)
     end end
 end
 

--- a/test/test_virtualprocess.jl
+++ b/test/test_virtualprocess.jl
@@ -13,6 +13,18 @@
         @test !isempty(res.toplevel_error_reports)
         @test first(res.toplevel_error_reports) isa SyntaxErrorReport
     end
+
+    let
+        res, interp = @profile_toplevel begin
+            let
+                const s = "julia" # `const` annotation is prohibited on local scope
+                sum(s)
+            end
+        end
+
+        @test !isempty(res.toplevel_error_reports)
+        @test first(res.toplevel_error_reports) isa SyntaxErrorReport
+    end
 end
 
 @testset "\"toplevel definitions\"" begin
@@ -180,7 +192,7 @@ end
     end
 end
 
-@testset "remove `const`" begin
+@testset "handle `const`" begin
     let
         res, interp = @profile_toplevel begin
             const s = "julia"
@@ -189,18 +201,6 @@ end
 
         @test isempty(res.toplevel_error_reports)
         test_sum_over_string(res)
-    end
-
-    let
-        res, interp = @profile_toplevel begin
-            let
-                const s = "julia"
-                sum(s)
-            end
-        end
-
-        @test !isempty(res.toplevel_error_reports)
-        @test first(res.toplevel_error_reports) isa SyntaxErrorReport
     end
 end
 


### PR DESCRIPTION
this will get rid of most of the hacky trasformations on ASTs, and maybe make virtual toplevel execution simulation more robust in general

remainings:
- [ ] partial evaluation of toplevel code
- [ ] pass tests

closes #21 , #26 
