### PR TITLE
rm reconstruction of cached reports, just force inference on "errorne…

### DIFF
--- a/src/abstractinterpretation.jl
+++ b/src/abstractinterpretation.jl
@@ -211,9 +211,9 @@ function typeinf(interp::TPInterpreter, frame::InferenceState)
     set_current_frame!(interp, frame)
 
     # throw away previously-collected error reports that have a lineage of this frame if we
-    # re-infer this frame with constant propagation, because results with constants are
-    # always more accurate than those without them; this can happen only _after_
-    # abstract interpretation without constants (i.e. just using `atype`)
+    # re-infer this frame with constant propagation, assuming results with constants are
+    # always more accurate than those without them (COMBAK: is this really true ?); this can
+    # happen only _after_ abstract interpretation without constants (i.e. just using `atype`)
     #
     # xref (maybe coming future change of constant propagation logic):
     # https://github.com/JuliaLang/julia/blob/a108d6cb8fdc7924fe2b8d831251142386cb6525/base/compiler/abstractinterpretation.jl#L153

--- a/src/abstractinterpreterinterface.jl
+++ b/src/abstractinterpreterinterface.jl
@@ -83,6 +83,8 @@ function gen_opt_params()
     )
 end
 
+get_id(interp::TPInterpreter) = interp.id
+
 InferenceParams(interp::TPInterpreter) = InferenceParams(interp.native)
 OptimizationParams(interp::TPInterpreter) = OptimizationParams(interp.native)
 get_world_counter(interp::TPInterpreter) = get_world_counter(interp.native)

--- a/src/tpcache.jl
+++ b/src/tpcache.jl
@@ -1,51 +1,3 @@
-# report cache
-# ------------
-
-struct InferenceReportCache{T<:InferenceErrorReport}
-    st::ViewedVirtualStackTrace
-    msg::String
-    sig::Vector{Any}
-    lineage::Lineage
-    args::NTuple{N, Any} where N # additional field that keeps information specific to `T`
-end
-
-const TPCACHE = IdDict{MethodInstance,Pair{Symbol,Vector{InferenceReportCache}}}()
-
-is_lineage(linfo::MethodInstance, cached_report::InferenceReportCache) =
-    is_lineage(linfo, cached_report.lineage)
-
-get_id(interp::TPInterpreter) = interp.id
-
-function restore_cached_report!(cache::InferenceReportCache{T}, interp) where {T<:InferenceErrorReport}
-    report = _restore_cached_report!(T, cache, interp)
-    push!(interp.reports, report)
-end
-
-function restore_cached_report!(cache::InferenceReportCache{ExceptionReport}, interp)
-    report = _restore_cached_report!(ExceptionReport, cache, interp)
-    push!(interp.exception_reports, length(interp.reports) => report)
-end
-
-function _restore_cached_report!(T, cache, interp)
-    sv = get_current_frame(interp)
-
-    # reconstruct virtual stack trace and lineage for this cached report
-    msg = cache.msg
-    sig = cache.sig
-    st = collect(cache.st)
-    lineage = Lineage(sf.linfo for sf in st)
-    cache_report! = gen_report_cacher(st, msg, sig, lineage, T, interp, #= dead arg =# sv, cache.args...)
-
-    prewalk_inf_frame(sv) do frame::InferenceState
-        linfo = frame.linfo
-        push!(st, get_virtual_frame(frame))
-        push!(lineage, linfo)
-        haskey(TPCACHE, linfo) || cache_report!(linfo) # caller can be already cached
-    end
-
-    return T(st, cache.msg, cache.sig, lineage, cache.args)
-end
-
 # code cache interface
 # --------------------
 
@@ -65,21 +17,27 @@ CC.haskey(tpc::TPCache, mi::MethodInstance) = CC.haskey(tpc.native, mi)
 function CC.get(tpc::TPCache, mi::MethodInstance, default)
     ret = CC.get(tpc.native, mi, default)
 
-    # cache hit, we need to append already-profiled error reports if exist
-    if ret !== default
-        if haskey(TPCACHE, mi)
-            id, cached_reports = TPCACHE[mi]
+    ret === default && return default
 
-            # don't append duplicated reports from the same inference process
-            if id !== get_id(tpc.interp)
-                for cache in cached_reports
-                    restore_cached_report!(cache, tpc.interp)
-                end
-            end
-        end
+    # cache hit, now we need to invalidate the cache lookup if this `mi` has been profiled
+    # as erroneous; otherwise the error reports that can occur from this frame will just be
+    # ignored
+    force_inference = false
+    if mi in ERRORNEOUS_LINFOS
+        force_inference = true
     end
 
-    return ret
+    # # something like this won't force inference for frames from the same inference process,
+    # # which may speed up inference performance
+    # if haskey(ERRORNEOUS_LINFOS, mi)
+    #     id = ERRORNEOUS_LINFOS[mi]
+    #
+    #     if id !== get_id(tpc.interp)
+    #         force_inference = true
+    #     end
+    # end
+
+    return force_inference ? default : ret
 end
 
 CC.getindex(tpc::TPCache, mi::MethodInstance) = CC.getindex(tpc.native, mi)

--- a/src/tpcache.jl
+++ b/src/tpcache.jl
@@ -23,19 +23,13 @@ function CC.get(tpc::TPCache, mi::MethodInstance, default)
     # as erroneous; otherwise the error reports that can occur from this frame will just be
     # ignored
     force_inference = false
-    if mi in ERRORNEOUS_LINFOS
-        force_inference = true
+    if haskey(ERRORNEOUS_LINFOS, mi)
+        # don't force re-inference for frames from the same inference process (which is judged
+        # by `TPInterpreter`'s id) since we already collected the errors from this frame
+        if ERRORNEOUS_LINFOS[mi] !== get_id(tpc.interp)
+            force_inference = true
+        end
     end
-
-    # # something like this won't force inference for frames from the same inference process,
-    # # which may speed up inference performance
-    # if haskey(ERRORNEOUS_LINFOS, mi)
-    #     id = ERRORNEOUS_LINFOS[mi]
-    #
-    #     if id !== get_id(tpc.interp)
-    #         force_inference = true
-    #     end
-    # end
 
     return force_inference ? default : ret
 end

--- a/test/test_abstractinterpretation.jl
+++ b/test/test_abstractinterpretation.jl
@@ -141,13 +141,17 @@
             end)
             @test isempty(interp.reports)
 
-            # for this case, we want to have union-split error, but the previous constant
-            # propagation excludes the report bound to `foo(::Union{Int,String})` from cache
-            # and so we can't get error report ...
+            # for this case, we want to have union-split error
             interp, frame = Core.eval(m, quote
-                $(profile_call)(()->bar(rand(Int)))
+                $(profile_call)(Int) do a
+                    bar(a)
+                end
             end)
-            @test_broken length(interp.reports) === 1
+            @test length(interp.reports) === 1
+            er = first(interp.reports)
+            @test er isa NoMethodErrorReport &&
+                er.unionsplit &&
+                er.atype ⊑ Tuple{Any,Union{Int,String},Int}
 
             # if we run constant propagation again, we can get reports as expected
             interp, frame = Core.eval(m, quote

--- a/test/test_abstractinterpretation.jl
+++ b/test/test_abstractinterpretation.jl
@@ -143,9 +143,7 @@
 
             # for this case, we want to have union-split error
             interp, frame = Core.eval(m, quote
-                $(profile_call)(Int) do a
-                    bar(a)
-                end
+                $(profile_call)(bar, Int)
             end)
             @test length(interp.reports) === 1
             er = first(interp.reports)


### PR DESCRIPTION
…ous" frames

- previous "cache clean up" logic potentially throws away true positive 
errors, while we need that to surpress false positives that can be 
revealed by constant propagation
- this commit removes the whole reconstructions of cached reports, and 
just force inference on those "erronesout" `MethodInstance`s by 
returning `default` fallback value to `CC.get(tpc::TPCache, 
mi::MethodInstance, default)`
- as a result, those "erronesous" frames will always re-run inference and
so constant propagation will reveal false/true positives whatever it's cached
(just because it ignores the cache)
- this may slow down abstract interpretation performance, but cache ignorance
is only done partially and so hopefully performance won't get so worse (I hope)
- at the cost of that, this will simplify the whole code **a lot** and also resolves
the previous problems of cache clean up of true positive reports