### PR TITLE
virtual global variable powerup

### DIFF
--- a/src/abstractinterpreterinterface.jl
+++ b/src/abstractinterpreterinterface.jl
@@ -20,9 +20,6 @@ struct TPInterpreter <: AbstractInterpreter
     # keeps `throw` calls that are not caught within a single frame
     exception_reports::Vector{Pair{Int,ExceptionReport}}
 
-    # keeps virtual global variable; module -> (sym -> (id, type, λ sym, method instance))
-    virtual_globalvar_table::Dict{Module,Dict{Symbol,Tuple{Symbol,Any,Symbol,MethodInstance}}}
-
     # disables caching of native remarks (that may vastly speed up profiling time)
     filter_native_remarks::Bool
 
@@ -35,7 +32,6 @@ struct TPInterpreter <: AbstractInterpreter
                            id                      = gensym(:TPInterpreterID),
                            reports                 = [],
                            exception_reports       = [],
-                           virtual_globalvar_table = Dict(),
                            filter_native_remarks   = true,
                            )
         @assert !opt_params.inlining "inlining should be disabled"
@@ -48,7 +44,6 @@ struct TPInterpreter <: AbstractInterpreter
                    id,
                    reports,
                    exception_reports,
-                   virtual_globalvar_table,
                    filter_native_remarks,
                    )
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,8 +7,8 @@ import Core.Compiler:
     widenconst
 
 import TypeProfiler:
-    TPInterpreter, profile_call, get_result, virtual_process!, hastopleveldef, report_errors,
-    get_virtual_globalvar, ToplevelErrorReport, InferenceErrorReport, print_reports
+    TPInterpreter, VirtualGlobalVariable, profile_call, get_result, virtual_process!,
+    hastopleveldef, report_errors, ToplevelErrorReport, InferenceErrorReport, print_reports
 
 for sym in Symbol.(last.(Base.Fix2(split, '.').(string.(vcat(subtypes(TypeProfiler, ToplevelErrorReport),
                                                              subtypes(TypeProfiler, InferenceErrorReport),
@@ -90,6 +90,11 @@ function _profile_toplevel(virtualmod, ex, lnn)
         ret = $(TypeProfiler.gen_virtual_process_result)()
         $(virtual_process!)($(toplevelex), $(string(lnn.file)), :Main, $(esc(virtualmod)), interp, ret)
     end end
+end
+
+function get_virtual_globalvar(vmod, sym, unwrap = true)
+    isdefined(vmod, sym) || return nothing
+    return getfield(vmod, sym)
 end
 
 # %% test body

--- a/test/test_abstractinterpretation.jl
+++ b/test/test_abstractinterpretation.jl
@@ -176,7 +176,8 @@ end
             sum(s)
         end
 
-        @test widenconst(get_virtual_globalvar(interp, vmod, :s)) == String
+        s = get_virtual_globalvar(vmod, :s)
+        @test s isa VirtualGlobalVariable && s.t ⊑ String
         test_sum_over_string(res)
     end
 
@@ -192,7 +193,8 @@ end
                 end
             end))
 
-            @test get_virtual_globalvar(interp, vmod, :globalvar) === Union{String,Symbol}
+            globalvar = get_virtual_globalvar(vmod, :globalvar)
+            @test globalvar isa VirtualGlobalVariable && globalvar.t === Union{String,Symbol}
         end
 
         let
@@ -208,7 +210,8 @@ end
                 foo(globalvar) # union-split no method matching error should be reported
             end
 
-            @test get_virtual_globalvar(interp, vmod, :globalvar) === Union{String,Symbol}
+            globalvar = get_virtual_globalvar(vmod, :globalvar)
+            @test globalvar isa VirtualGlobalVariable && globalvar.t === Union{String,Symbol}
             @test length(res.inference_error_reports) === 1
             er = first(res.inference_error_reports)
             @test er isa NoMethodErrorReport &&
@@ -232,7 +235,8 @@ end
                 foo(globalvar) # no method matching error should be reported
             end
 
-            @test get_virtual_globalvar(interp, vmod, :globalvar) ⊑ Int
+            globalvar = get_virtual_globalvar(vmod, :globalvar)
+            @test globalvar isa VirtualGlobalVariable && globalvar.t ⊑ Int
             @test length(res.inference_error_reports) === 2
             let er = first(res.inference_error_reports)
                 @test er isa NoMethodErrorReport &&

--- a/test/test_virtualprocess.jl
+++ b/test/test_virtualprocess.jl
@@ -514,19 +514,15 @@ end
 
         let
             vmod = gen_virtualmod()
-            @test_broken try
-                res, interp = @profile_toplevel vmod begin
-                    begin
-                        local localvar
-                        localvar = rand(Bool) # this shouldn't be annotated as `global`
-                        globalvar = localvar
-                    end
+            res, interp = @profile_toplevel vmod begin
+                begin
+                    local localvar
+                    localvar = rand(Bool) # this shouldn't be annotated as `global`
+                    globalvar = localvar
                 end
-                @test isnothing(get_virtual_globalvar(interp, vmod, :localvar))
-                @test !isnothing(get_virtual_globalvar(interp, vmod, :globalvar))
-            catch
-                false
             end
+            @test isnothing(get_virtual_globalvar(interp, vmod, :localvar))
+            @test !isnothing(get_virtual_globalvar(interp, vmod, :globalvar))
         end
 
         let


### PR DESCRIPTION
- improve toplevel assignment scope
- define our own object for virtual global variable, instead of keeping them in `interp.virtual_globalvar_table`:
  * allows `using`/`import` with virtual global variable to works
  * maybe more robust