### PR TITLE
power up abstract interpretation

### DIFF
--- a/src/abstractinterpretation.jl
+++ b/src/abstractinterpretation.jl
@@ -506,8 +506,6 @@ function typeinf(interp::TPInterpreter, frame::InferenceState)
     return ret
 end
 
-is_constant_propagated(frame) = CC.any(frame.result.overridden_by_const)
-
 const CONSTANT_PROP_METHODS = Set((:getproperty, :setproperty!))
 
 is_unreachable(@nospecialize(_)) = false

--- a/src/abstractinterpretation.jl
+++ b/src/abstractinterpretation.jl
@@ -494,6 +494,8 @@ function typeinf(interp::TPInterpreter, frame::InferenceState)
     return ret
 end
 
+is_constant_propagated(frame) = CC.any(frame.result.overridden_by_const)
+
 is_unreachable(@nospecialize(_)) = false
 is_unreachable(rn::ReturnNode)   = !isdefined(rn, :val)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -123,36 +123,6 @@ abstract_isa(vgv, @nospecialize(typ)) = isa(vgv, VirtualGlobalVariable) && vgv.t
     @static Sys.iswindows() || @testset "print.jl" begin
         include("test_print.jl")
     end
-
-    @testset "is it truly necessary ?" begin
-        let
-            # constant propagation can help to exclude false positive alerts;
-            # well, this is really bad code so I rather feel we may want to have a report
-            # for this case
-            res, interp = @profile_toplevel begin
-                function foo(n)
-                    if n < 10
-                        return n
-                    else
-                        return "over 10"
-                    end
-                end
-
-                function bar(n)
-                    if n < 10
-                        return foo(n) + 1
-                    else
-                        return foo(n) * "+1"
-                    end
-                end
-
-                bar(1)
-                bar(10)
-            end
-
-            @test isempty(res.inference_error_reports)
-        end
-    end
 end
 
 # # favorite

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,11 @@
 
 using Test, TypeProfiler, InteractiveUtils
 
+# show version info in CI
+if get(ENV, "CI", nothing) == "true"
+    versioninfo()
+end
+
 import Core.Compiler:
     widenconst
 

--- a/test/test_abstractinterpretation.jl
+++ b/test/test_abstractinterpretation.jl
@@ -502,6 +502,17 @@ end
     end
 end
 
+# upstream: https://github.com/JuliaLang/julia/pull/37830
+@testset "keyword argument methods" begin
+    interp, frame = Core.eval(gen_virtualmod(), quote
+        f(a; b = nothing, c = nothing) = return
+        $(profile_call)((Any,)) do b
+            f(1; b)
+        end
+    end)
+    @test isempty(interp.reports)
+end
+
 @testset "don't early escape if type grows up to `Any`" begin
     vmod = gen_virtualmod()
     res, interp = @profile_toplevel vmod begin

--- a/test/test_abstractinterpretation.jl
+++ b/test/test_abstractinterpretation.jl
@@ -535,7 +535,7 @@ end
 
 # upstream: https://github.com/JuliaLang/julia/pull/37830
 @testset "keyword argument methods" begin
-    interp, frame = Core.eval(gen_virtualmod(), quote
+    interp, frame = Core.eval(gen_virtual_module(), quote
         f(a; b = nothing, c = nothing) = return
         $(profile_call)((Any,)) do b
             f(1; b)
@@ -545,7 +545,7 @@ end
 end
 
 @testset "don't early escape if type grows up to `Any`" begin
-    vmod = gen_virtualmod()
+    vmod = gen_virtual_module()
     res, interp = @profile_toplevel vmod begin
         abstract type Foo end
         struct Foo1 <: Foo


### PR DESCRIPTION
- monkey-patching `abstract_call_gf_by_type` so that it collects as much error points as possible
- closes #43 by fixing upstream (native) interpreter
- ban constant prop' report throw aways, get more reports, stable reports for cached frames